### PR TITLE
Fix incorrect indent

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -43,7 +43,7 @@ setlocal autoindent
 
 " Inline comments (for anchoring other statements)
 let s:js_mid_line_comment = '\s*\(\/\*.*\*\/\)*\s*'
-let s:js_end_line_comment = s:js_mid_line_comment . '\s*\(\/\/.*\)*'
+let s:js_end_line_comment = s:js_mid_line_comment . '\s*\([^:]\\?\/\/.*\)*'
 let s:js_line_comment = s:js_end_line_comment
 
 " Comment/string syntax key


### PR DESCRIPTION
Statement like `console.log('Server running at http://127.0.0.1:4000/');` were considered as a parens start.

``` javascript
console.log('Server running at http://127.0.0.1:4000/');<return>
```

expect

``` javascript
console.log('Server running at http://127.0.0.1:4000/');
|
```

but performance is

``` javascript
console.log('Server running at http://127.0.0.1:4000/');
    |
```
